### PR TITLE
Clear the Kubernetes `auth-info` in `cf api` and `cf logout`

### DIFF
--- a/actor/v7action/target.go
+++ b/actor/v7action/target.go
@@ -44,4 +44,5 @@ func (actor Actor) SetTarget(settings TargetSettings) (Warnings, error) {
 func (actor Actor) ClearTarget() {
 	actor.Config.SetTargetInformation(configv3.TargetInformationArgs{})
 	actor.Config.SetTokenInformation("", "", "")
+	actor.Config.SetKubernetesAuthInfo("")
 }

--- a/actor/v7action/target.go
+++ b/actor/v7action/target.go
@@ -35,6 +35,7 @@ func (actor Actor) SetTarget(settings TargetSettings) (Warnings, error) {
 	})
 
 	actor.Config.SetTokenInformation("", "", "")
+	actor.Config.SetKubernetesAuthInfo("")
 
 	return allWarnings, nil
 }

--- a/actor/v7action/target_test.go
+++ b/actor/v7action/target_test.go
@@ -131,6 +131,13 @@ var _ = Describe("Targeting", func() {
 			Expect(sshOAuthClient).To(BeEmpty())
 		})
 
+		It("clears the Kubernetes auth-info", func() {
+			Expect(fakeConfig.SetKubernetesAuthInfoCallCount()).To(Equal(1))
+			authInfo := fakeConfig.SetKubernetesAuthInfoArgsForCall(0)
+
+			Expect(authInfo).To(BeEmpty())
+		})
+
 		It("succeeds and returns all warnings", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(warnings).To(ConsistOf(Warnings{"info-warning"}))

--- a/actor/v7action/target_test.go
+++ b/actor/v7action/target_test.go
@@ -183,5 +183,14 @@ var _ = Describe("Targeting", func() {
 			Expect(refreshToken).To(BeEmpty())
 			Expect(sshOAuthClient).To(BeEmpty())
 		})
+
+		It("clears the Kubernetes auth-info", func() {
+			actor.ClearTarget()
+
+			Expect(fakeConfig.SetKubernetesAuthInfoCallCount()).To(Equal(1))
+			authInfo := fakeConfig.SetKubernetesAuthInfoArgsForCall(0)
+
+			Expect(authInfo).To(BeEmpty())
+		})
 	})
 })

--- a/integration/v7/selfcontained/api_command_test.go
+++ b/integration/v7/selfcontained/api_command_test.go
@@ -77,3 +77,23 @@ var _ = Describe("cf api", func() {
 		})
 	})
 })
+
+var _ = Describe("cf api --unset", func() {
+	BeforeEach(func() {
+		helpers.SetConfig(func(config *configv3.Config) {
+			config.ConfigFile.CFOnK8s.Enabled = true
+			config.ConfigFile.CFOnK8s.AuthInfo = "something"
+		})
+	})
+
+	JustBeforeEach(func() {
+		Eventually(helpers.CF("api", "--unset")).Should(gexec.Exit(0))
+	})
+
+	It("disables cf-on-k8s in config and clears the auth-info", func() {
+		Expect(loadConfig().CFOnK8s).To(Equal(configv3.CFOnK8s{
+			Enabled:  false,
+			AuthInfo: "",
+		}))
+	})
+})

--- a/integration/v7/selfcontained/logout_command_test.go
+++ b/integration/v7/selfcontained/logout_command_test.go
@@ -1,0 +1,29 @@
+package selfcontained_test
+
+import (
+	"code.cloudfoundry.org/cli/integration/helpers"
+	"code.cloudfoundry.org/cli/util/configv3"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("cf logout", func() {
+	BeforeEach(func() {
+		helpers.SetConfig(func(config *configv3.Config) {
+			config.ConfigFile.CFOnK8s.Enabled = true
+			config.ConfigFile.CFOnK8s.AuthInfo = "something"
+		})
+	})
+
+	JustBeforeEach(func() {
+		Eventually(helpers.CF("logout")).Should(gexec.Exit(0))
+	})
+
+	It("clears the auth-info", func() {
+		Expect(loadConfig().CFOnK8s).To(Equal(configv3.CFOnK8s{
+			Enabled:  true,
+			AuthInfo: "",
+		}))
+	})
+})

--- a/util/configv3/json_config.go
+++ b/util/configv3/json_config.go
@@ -304,6 +304,7 @@ func (config *Config) UnsetUserInformation() {
 	config.SetRefreshToken("")
 	config.SetUAAGrantType("")
 	config.SetUAAClientCredentials(DefaultUAAOAuthClient, DefaultUAAOAuthClientSecret)
+	config.SetKubernetesAuthInfo("")
 
 	config.UnsetOrganizationAndSpaceInformation()
 }

--- a/util/configv3/json_config_test.go
+++ b/util/configv3/json_config_test.go
@@ -479,6 +479,7 @@ var _ = Describe("JSONConfig", func() {
 			config.SetUAAClientCredentials("some-client", "some-client-secret")
 			config.SetOrganizationInformation("some-org-guid", "some-org")
 			config.SetSpaceInformation("guid-value-1", "my-org-name", true)
+			config.SetKubernetesAuthInfo("some-auth-info")
 		})
 
 		It("resets all user information", func() {
@@ -494,6 +495,7 @@ var _ = Describe("JSONConfig", func() {
 			Expect(config.ConfigFile.UAAGrantType).To(BeEmpty())
 			Expect(config.ConfigFile.UAAOAuthClient).To(Equal(DefaultUAAOAuthClient))
 			Expect(config.ConfigFile.UAAOAuthClientSecret).To(Equal(DefaultUAAOAuthClientSecret))
+			Expect(config.ConfigFile.CFOnK8s.AuthInfo).To(BeEmpty())
 		})
 	})
 


### PR DESCRIPTION
This makes sure that the Kubernetes `auth-info` is cleared when the user switches to a different CF (either on VMS or on K8s) via `cf api`, or when they `cf api --unset` or `cf logout`.

In the `cf logout` case, the `Enabled` flag is left to `true` so that the user can log back in with a simple `cf login`.